### PR TITLE
Refactor separate evaluate and scrapper function

### DIFF
--- a/src/scrapers/sentry.js
+++ b/src/scrapers/sentry.js
@@ -1,92 +1,71 @@
 import logger from "../utils/logger.js";
-import {
-  parseJobDescription,
-  defaultKeywordSets,
-  createKeywordMatcher,
-} from "../utils/jobDescriptionParser.js";
+import { scrape } from '../utils/scrapper.js'
 
 const SENTRY_JOBS_URL = "https://sentry.io/careers/";
 
-export async function scrapeSentry(browser) {
-  const page = await browser.newPage();
-  try {
-    logger.info("Navigating to Sentry jobs page");
-    await page.goto(SENTRY_JOBS_URL, { waitUntil: "networkidle0" });
+export async function getSentryJobs() {
+  const departmentElements = document.querySelectorAll("#openings > div");
 
-    const jobs = await page.evaluate(() => {
-      const departmentElements = document.querySelectorAll("#openings > div");
-      return Array.from(departmentElements).map((element) => {
-        const department = element.querySelector("h3").textContent.trim() || "";
-        const jobElements = element.querySelectorAll("a[href^='/careers']");
-        return Array.from(jobElements).map((jobElement) => ({
-          title: jobElement.textContent.trim(),
+  return Array.from(departmentElements)
+    .map((element) => {
+      const department = element.querySelector("h3")?.textContent.trim() || "";
+      const jobElements = element.querySelectorAll("a[href^='/careers']");
+      return Array.from(jobElements)
+        .map((jobElement) => ({
+          title: jobElement?.textContent.trim() || "",
           url: jobElement.href,
           company: "Sentry",
           location: jobElement.querySelector("p")?.textContent.trim() || "",
           department,
         }));
-      }).flat();
-    });
+    }).flat();
+}
 
-    logger.info(`Found ${jobs.length} Sentry jobs. Scraping details...`);
+export async function getSentryJobDetail() {
+  const extractCompanyInfo = () => {
+    const introElement = document.querySelector(".content-intro");
+    const contentElement = introElement.querySelectorAll("p");
+    return Array.from(contentElement)
+      .map((el) => el.textContent.trim() || "")
+      .join("\n");
+  };
 
-    for (const job of jobs) {
-      try {
-        await page.goto(job.url, { waitUntil: "networkidle0" });
-        const jobDetails = await page.evaluate(() => {
-          const extractCompanyInfo = () => {
-            const introElement = document.querySelector(".content-intro");
-            const contentElement = introElement.querySelectorAll("p");
-            return Array.from(contentElement)
-              .map((el) => el.textContent.trim() || "")
-              .join("\n");
-          };
-
-          const findSectionContent = (headingText) => {
-            const headings = Array.from(document.querySelectorAll("h2"));
-            const targetHeading = headings.find((h) =>
-              h.textContent.toLowerCase().includes(headingText.toLowerCase()),
-            );
-            if (targetHeading) {
-              let content = "";
-              let nextElem = targetHeading.nextElementSibling;
-              while (nextElem && nextElem.tagName !== "H2") {
-                content += nextElem.innerText + "\n";
-                nextElem = nextElem.nextElementSibling;
-              }
-              return content.trim();
-            }
-            return "";
-          };
-
-          return {
-            description: document.querySelector(".content-intro")
-              .parentElement.textContent.trim() || "",
-            // salary: extractSalaryInfo(),
-            requirements: findSectionContent("Qualifications"),
-            responsibilities: findSectionContent("In this role you will"),
-            // benefits: findSectionContent("Benefits"),
-            companyDescription: extractCompanyInfo(),
-            // teamDescription: findSectionContent("Team Description"),
-            roleDescription: findSectionContent("About the role"),
-          };
-        });
-
-        Object.assign(job, jobDetails);
-
-        logger.info(`Scraped details for job: ${job.title}`);
-      } catch (error) {
-        logger.error(
-          `Error scraping details for job ${job.title}: ${error.message}`,
-        );
+  const findSectionContent = (headingText) => {
+    const headings = Array.from(document.querySelectorAll("h2"));
+    const targetHeading = headings.find((h) =>
+      h.textContent.toLowerCase().includes(headingText.toLowerCase()),
+    );
+    if (targetHeading) {
+      let content = "";
+      let nextElem = targetHeading.nextElementSibling;
+      while (nextElem && nextElem.tagName !== "H2") {
+        content += nextElem.innerText + "\n";
+        nextElem = nextElem.nextElementSibling;
       }
+      return content.trim();
     }
+    return "";
+  };
 
-    return jobs;
+  return {
+    description: document.querySelector(".content-intro")
+      .parentElement.textContent.trim() || "",
+    requirements: findSectionContent("Qualifications"),
+    responsibilities: findSectionContent("In this role you will"),
+    companyDescription: extractCompanyInfo(),
+    roleDescription: findSectionContent("About the role"),
+  };
+}
+
+export async function scrapeSentry(browser) {
+  try {
+    logger.info("Scraping Sentry jobs page ...");
+    return await scrape(browser, SENTRY_JOBS_URL, {
+      jobListing: getSentryJobs, 
+      jobDetail: getSentryJobDetail,
+    });
   } catch (error) {
     logger.error(`Error scraping Sentry jobs: ${error.message}`);
     throw error;
-  } finally {
-    await page.close();
   }
 }

--- a/src/utils/scrapper.js
+++ b/src/utils/scrapper.js
@@ -1,0 +1,37 @@
+import logger from "./logger.js";
+
+export async function scrape(browser, url, scrapper) {
+  const {jobListing, jobDetail} = scrapper;
+  const page = await browser.newPage();
+  try {
+    await page.goto(url, { waitUntil: "networkidle0" });
+    const jobs = await page.evaluate(jobListing);
+
+    logger.info(`Found ${jobs.length} jobs. Scraping details...`);
+
+    if (!jobDetail) {
+      return jobs;
+    }
+
+    for (const job of jobs) {
+      try {
+        await page.goto(job.url, { waitUntil: "networkidle0" });
+        const jobDetails = await page.evaluate(jobDetail);
+
+        Object.assign(job, jobDetails);
+
+        logger.info(`Scraped details for job: ${job.title}`);
+      } catch (error) {
+        logger.error(
+          `Error scraping details for job ${job.title}: ${error.message}`,
+        );
+      }
+    }
+
+    return jobs;
+  } catch (error) {
+    throw error;
+  } finally {
+    await page.close();
+  }
+}


### PR DESCRIPTION
Since the different logic for scrapping careers from all companies is the HTML on their page. I think we can separate Puppeteer code and evaluate page code.

<img width="1792" alt="image" src="https://github.com/user-attachments/assets/488ca181-7224-4c5e-b9b5-9c40971e9ca7">
